### PR TITLE
Create a new issue template for generic issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/default-new.md
+++ b/.github/ISSUE_TEMPLATE/default-new.md
@@ -1,6 +1,8 @@
 ---
 name: Issue
 about: This template is for a generic new issue.
+assignees: Marie-L, AbigailMesrenyameDogbe
+labels: new
 ---
 
 
@@ -17,3 +19,6 @@ about: This template is for a generic new issue.
 **Do you want to work on this issue (Yes/No)?**
 
 <!-- Let us know if you're interested in working on this issue. -->
+<!--Tag any relevant parties for review for this issue. -->
+
+cc / @pyladies/communications

--- a/.github/ISSUE_TEMPLATE/default-new.md
+++ b/.github/ISSUE_TEMPLATE/default-new.md
@@ -1,0 +1,19 @@
+---
+name: Issue
+about: This template is for a generic new issue.
+---
+
+
+<!-- This template provides suggestions for what you might want to add to your issue. Feel free to add or exclude sections.-->
+
+**Summary**
+
+<!-- Tell us a bit about this issue. Is there a project you'd like to work on, a feature request, a bug, or do you have a question for the team? -->
+
+**Acceptance Criteria**
+
+<!-- When can we resolve this issue? What needs to be fixed, answered, or built before this is considered "done"? -->
+
+**Do you want to work on this issue (Yes/No)?**
+
+<!-- Let us know if you're interested in working on this issue. -->


### PR DESCRIPTION
Create a new issue template for generic issues including prompts in comments for summary, done criteria, and whether or not the requester wants to work on it.