### PR TITLE
Update PyLadies avatar list

### DIFF
--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -31,11 +31,11 @@ Brazil,Recife,https://hugovk.github.io/python-logos/pyladies/img/pyladiesrecife.
 Brazil,Ribeirão Preto,https://hugovk.github.io/python-logos/pyladies/img/Pyladies-RP.png,https://pyladies-rp.github.io/,pyladies_recife
 Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladies-salvador.png,https://pyladiessalvador.github.io/,pyladiessa
 Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladiessalvador.png,https://pyladiessalvador.github.io/,pyladiessa
-Brazil,Sergipe,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sergipe.svg,https://www.instagram.com/pyladiessergipe/
+Brazil,Sergipe,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sergipe.svg,https://www.instagram.com/pyladiessergipe/,
 Brazil,Sorocaba,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Sorocaba.png,https://www.facebook.com/PyLadiesSorocaba,pyladiesorocaba
-Brazil,Sul de Minas Gerais,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sul_de_minas.png,https://www.facebook.com/pyladiesmg/
+Brazil,Sul de Minas Gerais,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sul_de_minas.png,https://www.facebook.com/pyladiesmg/,
 Brazil,São Carlos,https://hugovk.github.io/python-logos/pyladies/img/pyladies-saocarlos.png,https://www.facebook.com/PyLadiesSaoCarlos,PyLadiesSanca
-Brazil,São José dos Campos,https://hugovk.github.io/python-logos/pyladies/img/PyLadies São José dos Campos.png,https://www.facebook.com/pyladiesSJC/
+Brazil,São José dos Campos,https://hugovk.github.io/python-logos/pyladies/img/PyLadies São José dos Campos.png,https://www.facebook.com/pyladiesSJC/,
 Brazil,São Luís,https://hugovk.github.io/python-logos/pyladies/img/pyladies-sao-luis.svg,https://www.instagram.com/pyladiesslz/,pyladiesslz
 Brazil,Teresina,https://hugovk.github.io/python-logos/pyladies/img/pyladiesteresina.png,https://pyladiesteresina.github.io/,pyladiesthe
 Brazil,Vale Do Paraiba,https://hugovk.github.io/python-logos/pyladies/img/pyladiesvale.png,http://vale.pyladies.com/,pyladiesvale

--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -1,16 +1,42 @@
-Country,Chapter,URL
-Brazil,Recife,https://pbs.twimg.com/profile_images/1168214071302348801/Jr3M0Dqz_400x400.jpg
-Brazil,Floripa,https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSt8x1l_MFLOGnrYBj0Nic87OKmHOahWH6L_g&usqp=CAU
-U.S.A,silicon valley,https://hugovk.github.io/python-logos/pyladies/img/siliconvalley.png
-Brazil,salvador,https://pyladiessalvador.github.io/img/author.png
-Brazil,socoraba,https://avatars0.githubusercontent.com/u/34819292?s=280&v=4
-Brazil,manaus,https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQWU365Vk8Dd446WQ3qE9cEhpm6uMPv4C6sOg&usqp=CAU
-Ghana,ghana,https://hugovk.github.io/python-logos/pyladies/img/PyladiesGhana.jpg
-,remote,https://hugovk.github.io/python-logos/pyladies/img/remote-logo.svg
-Mexico,mexico city,https://hugovk.github.io/python-logos/pyladies/img/MxPyladies.jpg
-Taiwan,Taiwan,https://hugovk.github.io/python-logos/pyladies/img/twgirl_logo.png
-India,Chennai,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesChennai.png
-Nigeria,Lautech,https://hugovk.github.io/python-logos/pyladies/img/PyladiesLautech.jpg
-Ireland,Dublin,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesDublin.jpg
-Spain,Barcelona,https://hugovk.github.io/python-logos/pyladies/img/PyLadies%20BCN.jpg
-Russia,saint petersburg,https://hugovk.github.io/python-logos/pyladies/img/pyladies_spb.png
+Country,Chapter,URL,Homepage,Twitter
+Ethiopia,Addis Ababa,https://hugovk.github.io/python-logos/pyladies/img/PyladiesAddis.png,https://github.com/PyladiesAddis
+Ghana,Ghana,https://hugovk.github.io/python-logos/pyladies/img/PyladiesGhana.jpg,https://ghana.pyladies.com/,pyladiesghana
+Nigeria,Lautech,https://hugovk.github.io/python-logos/pyladies/img/PyladiesLautech.jpg,https://twitter.com/PyladiesLautech,PyladiesLautech
+India,Chennai,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesChennai.png,https://www.meetup.com/pyladieschennai/,pyladieschennai
+Taiwan,Taiwan,https://hugovk.github.io/python-logos/pyladies/img/twgirl_logo.png,https://tw.pyladies.com/,PyLadiesTW
+Japan,Tokyo,https://hugovk.github.io/python-logos/pyladies/img/pyladies-tokyo.png,https://pyladiestokyo.github.io/,PyLadiesTokyo
+Spain,Barcelona,https://hugovk.github.io/python-logos/pyladies/img/PyLadies BCN.jpg,https://www.meetup.com/PyLadies-BCN/,PyLadiesBCN
+Ireland,Dublin,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesDublin.jpg,https://www.meetup.com/PyLadiesDublin/,pyladiesDub
+Russia,Kazan,https://hugovk.github.io/python-logos/pyladies/img/pyladieskzn.png,https://www.facebook.com/pyladieskzn,pyladieskzn
+Germany,Munich,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Munich.png,https://www.meetup.com/PyLadiesMunich/,pyladiesmunich
+Russia,Saint Petersburg,https://hugovk.github.io/python-logos/pyladies/img/pyladies_spb.png,http://spb.pyladies.com/,pyladies_spb
+Mexico,Mexico City,https://hugovk.github.io/python-logos/pyladies/img/MxPyladies.jpg,https://www.meetup.com/Mexico-City-Pyladies-Meetup/,MxPyladies
+USA,Seattle,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesSEA.png,https://www.meetup.com/Seattle-PyLadies/,PyLadiesSEA
+USA,Silicon Valley,https://hugovk.github.io/python-logos/pyladies/img/siliconvalley.png,https://www.meetup.com/PyLadies-Silicon-Valley/
+Brazil,Belém,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesBelém.png,https://www.facebook.com/pyladiesbelem
+Brazil,Blumenau,https://hugovk.github.io/python-logos/pyladies/img/pyladies-blumenau.png,https://www.facebook.com/groups/PyLadiesBlumenau/,pyladiesbnu
+Brazil,Brasília DF,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Brasília DF.png,https://df.pyladies.com/,PyLadiesDF
+Brazil,Brazil,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesBrasil.jpg,https://brasil.pyladies.com/,PyLadiesBrasil
+Brazil,Caxias do Sul,https://hugovk.github.io/python-logos/pyladies/img/PyladiesCaxias.jpg,https://pyladiescaxias.github.io/,PyladiesAracati
+Brazil,Florianópolis,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Florianópolis.jpg,https://www.facebook.com/groups/PyLadiesFlorianopolis/,PyLadiesFloripa
+Brazil,Fortaleza,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Fortaleza.png,https://www.facebook.com/PyLadiesFortaleza/,pyladiesfort
+Brazil,Goiânia,https://hugovk.github.io/python-logos/pyladies/img/pyladies-goiania.png,https://www.instagram.com/pyladies_goiania/
+Brazil,Maceió,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesMaceio.png,https://www.facebook.com/PyLadiesMaceio/,pyladiesmaceio
+Brazil,Manaus,https://hugovk.github.io/python-logos/pyladies/img/pyladiesmanaus.png,https://www.facebook.com/pyladiesmanaus/,pyladiesmanaus
+Brazil,Natal,https://hugovk.github.io/python-logos/pyladies/img/pyladies_natal.svg,https://pyladiesnatal.github.io/,PyladiesNatal
+Brazil,Paraíba,https://hugovk.github.io/python-logos/pyladies/img/pyladiespb.png,https://www.facebook.com/pyladiespb,pyladiespb
+Brazil,Parnaíba,https://hugovk.github.io/python-logos/pyladies/img/pyLadiesPHB.png,https://pyladiesparnaiba.carrd.co/,pyladiesphb
+Brazil,Porto Alegre,https://hugovk.github.io/python-logos/pyladies/img/pyladies-porto-alegre.png,https://pyladiespoa.pythonanywhere.com/,Pyladiespoa
+Brazil,Recife,https://hugovk.github.io/python-logos/pyladies/img/pyladiesrecife.png,https://linktr.ee/pyladiesrecife,pyladies_recife
+Brazil,Ribeirão Preto,https://hugovk.github.io/python-logos/pyladies/img/Pyladies-RP.png,https://pyladies-rp.github.io/,pyladies_recife
+Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladies-salvador.png,https://pyladiessalvador.github.io/,pyladiessa
+Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladiessalvador.png,https://pyladiessalvador.github.io/,pyladiessa
+Brazil,Sergipe,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sergipe.svg,https://www.instagram.com/pyladiessergipe/
+Brazil,Sorocaba,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Sorocaba.png,https://www.facebook.com/PyLadiesSorocaba,pyladiesorocaba
+Brazil,Sul de Minas Gerais,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sul_de_minas.png,https://www.facebook.com/pyladiesmg/
+Brazil,São Carlos,https://hugovk.github.io/python-logos/pyladies/img/pyladies-saocarlos.png,https://www.facebook.com/PyLadiesSaoCarlos,PyLadiesSanca
+Brazil,São José dos Campos,https://hugovk.github.io/python-logos/pyladies/img/PyLadies São José dos Campos.png,https://www.facebook.com/pyladiesSJC/
+Brazil,São Luís,https://hugovk.github.io/python-logos/pyladies/img/pyladies-sao-luis.svg,https://www.instagram.com/pyladiesslz/,pyladiesslz
+Brazil,Teresina,https://hugovk.github.io/python-logos/pyladies/img/pyladiesteresina.png,https://pyladiesteresina.github.io/,pyladiesthe
+Brazil,Vale Do Paraiba,https://hugovk.github.io/python-logos/pyladies/img/pyladiesvale.png,http://vale.pyladies.com/,pyladiesvale
+Global,Remote,https://hugovk.github.io/python-logos/pyladies/img/remote-logo.svg,https://remote.pyladies.com/,PyLadiesRemote

--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -38,4 +38,4 @@ Brazil,São José dos Campos,https://hugovk.github.io/python-logos/pyladies/img/
 Brazil,São Luís,https://hugovk.github.io/python-logos/pyladies/img/pyladies-sao-luis.svg,https://www.instagram.com/pyladiesslz/,pyladiesslz
 Brazil,Teresina,https://hugovk.github.io/python-logos/pyladies/img/pyladiesteresina.png,https://pyladiesteresina.github.io/,pyladiesthe
 Brazil,Vale Do Paraiba,https://hugovk.github.io/python-logos/pyladies/img/pyladiesvale.png,http://vale.pyladies.com/,pyladiesvale
-Global,Remote,https://hugovk.github.io/python-logos/pyladies/img/remote-logo.svg,https://remote.pyladies.com/,PyLadiesRemote
+Remote,Remote,https://hugovk.github.io/python-logos/pyladies/img/remote-logo.svg,https://remote.pyladies.com/,PyLadiesRemote

--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -1,5 +1,5 @@
 Country,Chapter,URL,Homepage,Twitter
-Ethiopia,Addis Ababa,https://hugovk.github.io/python-logos/pyladies/img/PyladiesAddis.png,https://github.com/PyladiesAddis
+Ethiopia,Addis Ababa,https://hugovk.github.io/python-logos/pyladies/img/PyladiesAddis.png,https://github.com/PyladiesAddis,
 Ghana,Ghana,https://hugovk.github.io/python-logos/pyladies/img/PyladiesGhana.jpg,https://ghana.pyladies.com/,pyladiesghana
 Nigeria,Lautech,https://hugovk.github.io/python-logos/pyladies/img/PyladiesLautech.jpg,https://twitter.com/PyladiesLautech,PyladiesLautech
 India,Chennai,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesChennai.png,https://www.meetup.com/pyladieschennai/,pyladieschennai
@@ -12,15 +12,15 @@ Germany,Munich,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Munic
 Russia,Saint Petersburg,https://hugovk.github.io/python-logos/pyladies/img/pyladies_spb.png,http://spb.pyladies.com/,pyladies_spb
 Mexico,Mexico City,https://hugovk.github.io/python-logos/pyladies/img/MxPyladies.jpg,https://www.meetup.com/Mexico-City-Pyladies-Meetup/,MxPyladies
 USA,Seattle,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesSEA.png,https://www.meetup.com/Seattle-PyLadies/,PyLadiesSEA
-USA,Silicon Valley,https://hugovk.github.io/python-logos/pyladies/img/siliconvalley.png,https://www.meetup.com/PyLadies-Silicon-Valley/
-Brazil,Belém,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesBelém.png,https://www.facebook.com/pyladiesbelem
+USA,Silicon Valley,https://hugovk.github.io/python-logos/pyladies/img/siliconvalley.png,https://www.meetup.com/PyLadies-Silicon-Valley/,
+Brazil,Belém,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesBelém.png,https://www.facebook.com/pyladiesbelem,
 Brazil,Blumenau,https://hugovk.github.io/python-logos/pyladies/img/pyladies-blumenau.png,https://www.facebook.com/groups/PyLadiesBlumenau/,pyladiesbnu
 Brazil,Brasília DF,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Brasília DF.png,https://df.pyladies.com/,PyLadiesDF
 Brazil,Brazil,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesBrasil.jpg,https://brasil.pyladies.com/,PyLadiesBrasil
 Brazil,Caxias do Sul,https://hugovk.github.io/python-logos/pyladies/img/PyladiesCaxias.jpg,https://pyladiescaxias.github.io/,PyladiesAracati
 Brazil,Florianópolis,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Florianópolis.jpg,https://www.facebook.com/groups/PyLadiesFlorianopolis/,PyLadiesFloripa
 Brazil,Fortaleza,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Fortaleza.png,https://www.facebook.com/PyLadiesFortaleza/,pyladiesfort
-Brazil,Goiânia,https://hugovk.github.io/python-logos/pyladies/img/pyladies-goiania.png,https://www.instagram.com/pyladies_goiania/
+Brazil,Goiânia,https://hugovk.github.io/python-logos/pyladies/img/pyladies-goiania.png,https://www.instagram.com/pyladies_goiania/,
 Brazil,Maceió,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesMaceio.png,https://www.facebook.com/PyLadiesMaceio/,pyladiesmaceio
 Brazil,Manaus,https://hugovk.github.io/python-logos/pyladies/img/pyladiesmanaus.png,https://www.facebook.com/pyladiesmanaus/,pyladiesmanaus
 Brazil,Natal,https://hugovk.github.io/python-logos/pyladies/img/pyladies_natal.svg,https://pyladiesnatal.github.io/,PyladiesNatal

--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -29,7 +29,6 @@ Brazil,Parnaíba,https://hugovk.github.io/python-logos/pyladies/img/pyLadiesPHB.
 Brazil,Porto Alegre,https://hugovk.github.io/python-logos/pyladies/img/pyladies-porto-alegre.png,https://pyladiespoa.pythonanywhere.com/,Pyladiespoa
 Brazil,Recife,https://hugovk.github.io/python-logos/pyladies/img/pyladiesrecife.png,https://linktr.ee/pyladiesrecife,pyladies_recife
 Brazil,Ribeirão Preto,https://hugovk.github.io/python-logos/pyladies/img/Pyladies-RP.png,https://pyladies-rp.github.io/,pyladies_recife
-Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladies-salvador.png,https://pyladiessalvador.github.io/,pyladiessa
 Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladiessalvador.png,https://pyladiessalvador.github.io/,pyladiessa
 Brazil,Sergipe,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sergipe.svg,https://www.instagram.com/pyladiessergipe/,
 Brazil,Sorocaba,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Sorocaba.png,https://www.facebook.com/PyLadiesSorocaba,pyladiesorocaba


### PR DESCRIPTION
This PR helps towards points 1, 2 and 4 of https://github.com/pyladies/project-communications/issues/63#issuecomment-667202397:

> Today we set up the automation using Zapier to update the avatar daily, and we also added the step to post a tweet about the new profile picture. Other suggested improvements to this are:
> 
> * add a column with link to the PyLadies chapter website/meetup so we can include it on the tweet
> * add a column with the PyLadies twitter account so we can @-mention them on twitter
> * some logo may need to be resized for twitter
> * add more logos


---

Hello!

I saw your video at https://twitter.com/mariatta/status/1289345727936659457, really good idea to rotate the Twitter avatar! Nice to see my https://hugovk.github.io/python-logos/pyladies/ being of use too :)

This PR updates the CSV to the full list of logos I've so far collected at https://hugovk.github.io/python-logos/pyladies/

The CSV now has columns for the homepage, and for Twitter username.

Note that some don't have a Twitter username listed: either they don't have one or I couldn't find it.

(Perhaps https://hugovk.github.io/python-logos/pyladies/ could even be refactored to load the list of logos from a CSV, then either the Zapier script could read that directly, or it'd make it easier to diff and add new ones to here (and the other direction too).)


