### PR TITLE
Remove .svg logos from twitter avatar rotation

### DIFF
--- a/pyladies_avatars_rotation.csv
+++ b/pyladies_avatars_rotation.csv
@@ -23,19 +23,15 @@ Brazil,Fortaleza,https://hugovk.github.io/python-logos/pyladies/img/PyLadies For
 Brazil,Goiânia,https://hugovk.github.io/python-logos/pyladies/img/pyladies-goiania.png,https://www.instagram.com/pyladies_goiania/,
 Brazil,Maceió,https://hugovk.github.io/python-logos/pyladies/img/PyLadiesMaceio.png,https://www.facebook.com/PyLadiesMaceio/,pyladiesmaceio
 Brazil,Manaus,https://hugovk.github.io/python-logos/pyladies/img/pyladiesmanaus.png,https://www.facebook.com/pyladiesmanaus/,pyladiesmanaus
-Brazil,Natal,https://hugovk.github.io/python-logos/pyladies/img/pyladies_natal.svg,https://pyladiesnatal.github.io/,PyladiesNatal
 Brazil,Paraíba,https://hugovk.github.io/python-logos/pyladies/img/pyladiespb.png,https://www.facebook.com/pyladiespb,pyladiespb
 Brazil,Parnaíba,https://hugovk.github.io/python-logos/pyladies/img/pyLadiesPHB.png,https://pyladiesparnaiba.carrd.co/,pyladiesphb
 Brazil,Porto Alegre,https://hugovk.github.io/python-logos/pyladies/img/pyladies-porto-alegre.png,https://pyladiespoa.pythonanywhere.com/,Pyladiespoa
 Brazil,Recife,https://hugovk.github.io/python-logos/pyladies/img/pyladiesrecife.png,https://linktr.ee/pyladiesrecife,pyladies_recife
 Brazil,Ribeirão Preto,https://hugovk.github.io/python-logos/pyladies/img/Pyladies-RP.png,https://pyladies-rp.github.io/,pyladies_recife
 Brazil,Salvador,https://hugovk.github.io/python-logos/pyladies/img/pyladiessalvador.png,https://pyladiessalvador.github.io/,pyladiessa
-Brazil,Sergipe,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sergipe.svg,https://www.instagram.com/pyladiessergipe/,
 Brazil,Sorocaba,https://hugovk.github.io/python-logos/pyladies/img/PyLadies Sorocaba.png,https://www.facebook.com/PyLadiesSorocaba,pyladiesorocaba
 Brazil,Sul de Minas Gerais,https://hugovk.github.io/python-logos/pyladies/img/pyladies_sul_de_minas.png,https://www.facebook.com/pyladiesmg/,
 Brazil,São Carlos,https://hugovk.github.io/python-logos/pyladies/img/pyladies-saocarlos.png,https://www.facebook.com/PyLadiesSaoCarlos,PyLadiesSanca
 Brazil,São José dos Campos,https://hugovk.github.io/python-logos/pyladies/img/PyLadies São José dos Campos.png,https://www.facebook.com/pyladiesSJC/,
-Brazil,São Luís,https://hugovk.github.io/python-logos/pyladies/img/pyladies-sao-luis.svg,https://www.instagram.com/pyladiesslz/,pyladiesslz
 Brazil,Teresina,https://hugovk.github.io/python-logos/pyladies/img/pyladiesteresina.png,https://pyladiesteresina.github.io/,pyladiesthe
 Brazil,Vale Do Paraiba,https://hugovk.github.io/python-logos/pyladies/img/pyladiesvale.png,http://vale.pyladies.com/,pyladiesvale
-Remote,Remote,https://hugovk.github.io/python-logos/pyladies/img/remote-logo.svg,https://remote.pyladies.com/,PyLadiesRemote


### PR DESCRIPTION
Removed several chapters' logos because .svg format is not accepted for twitter avatar.